### PR TITLE
Fix SMPLX loading bug

### DIFF
--- a/local_viewer.py
+++ b/local_viewer.py
@@ -23,6 +23,7 @@ import matplotlib
 
 from utils.viewer_utils import Mini3DViewer, Mini3DViewerConfig
 from gaussian_renderer import GaussianModel, FlameGaussianModel
+from scene.smplx_gaussian_model import SMPLXGaussianModel
 from gaussian_renderer import render
 from mesh_renderer import NVDiffRenderer
 
@@ -96,7 +97,10 @@ class LocalViewer(Mini3DViewer):
 
     def init_gaussians(self):
         # load gaussians
-        if (Path(self.cfg.point_path).parent / "flame_param.npz").exists():
+        point_dir = Path(self.cfg.point_path).parent if self.cfg.point_path is not None else Path('.')
+        if (point_dir / "smplx_param.npz").exists():
+            self.gaussians = SMPLXGaussianModel(self.cfg.sh_degree)
+        elif (point_dir / "flame_param.npz").exists():
             self.gaussians = FlameGaussianModel(self.cfg.sh_degree)
         else:
             self.gaussians = GaussianModel(self.cfg.sh_degree)

--- a/render.py
+++ b/render.py
@@ -27,6 +27,7 @@ from utils.general_utils import safe_state
 from argparse import ArgumentParser
 from arguments import ModelParams, PipelineParams, get_combined_args
 from gaussian_renderer import GaussianModel, FlameGaussianModel
+from scene.smplx_gaussian_model import SMPLXGaussianModel
 from mesh_renderer import NVDiffRenderer
 
 
@@ -104,8 +105,11 @@ def render_set(dataset : ModelParams, name, iteration, views, gaussians, pipelin
 def render_sets(dataset : ModelParams, iteration : int, pipeline : PipelineParams, skip_train : bool, skip_val : bool, skip_test : bool, render_mesh: bool):
     with torch.no_grad():
         if dataset.bind_to_mesh:
-            # gaussians = FlameGaussianModel(dataset.sh_degree, dataset.disable_flame_static_offset)
-            gaussians = FlameGaussianModel(dataset.sh_degree)
+            smplx_flag = os.path.exists(os.path.join(dataset.source_path, "canonical_smplx_param.json"))
+            if smplx_flag:
+                gaussians = SMPLXGaussianModel(dataset.sh_degree)
+            else:
+                gaussians = FlameGaussianModel(dataset.sh_degree)
         else:
             gaussians = GaussianModel(dataset.sh_degree)
         scene = Scene(dataset, gaussians, load_iteration=iteration, shuffle=False)

--- a/train.py
+++ b/train.py
@@ -36,7 +36,12 @@ def training(dataset, opt, pipe, testing_iterations, saving_iterations, checkpoi
     first_iter = 0
     tb_writer = prepare_output_and_logger(dataset)
     if dataset.bind_to_mesh:
-        gaussians = FlameGaussianModel(dataset.sh_degree, dataset.disable_flame_static_offset, dataset.not_finetune_flame_params)
+        smplx_flag = os.path.exists(os.path.join(dataset.source_path, "canonical_smplx_param.json"))
+        if smplx_flag:
+            from scene.smplx_gaussian_model import SMPLXGaussianModel
+            gaussians = SMPLXGaussianModel(dataset.sh_degree)
+        else:
+            gaussians = FlameGaussianModel(dataset.sh_degree, dataset.disable_flame_static_offset, dataset.not_finetune_flame_params)
         mesh_renderer = NVDiffRenderer()
     else:
         gaussians = GaussianModel(dataset.sh_degree)


### PR DESCRIPTION
## Summary
- support either FLAME or SMPL‑X parameters in dataset reader
- load SMPL‑X meshes even when expression dimensions vary across frames
- automatically choose SMPL‑X model for training, rendering and viewer when parameters exist

## Testing
- `python -m py_compile scene/dataset_readers.py train.py render.py local_viewer.py scene/smplx_gaussian_model.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb426f948832abe2c57c59b0b3d08