### PR TITLE
Add global PLY export script

### DIFF
--- a/save_global_ply.py
+++ b/save_global_ply.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import tyro
+
+from gaussian_renderer import GaussianModel, FlameGaussianModel
+from scene.smplx_gaussian_model import SMPLXGaussianModel
+
+@dataclass
+class Config:
+    point_path: Path
+    """Path to the local-coordinate Gaussian PLY file."""
+    output_path: Path
+    """Path to save the converted global-coordinate PLY file."""
+    motion_path: Optional[Path] = None
+    """Optional motion npz for dynamic models."""
+    timestep: int = 0
+    """Timestep to export when the model is dynamic."""
+    sh_degree: int = 3
+    """Spherical Harmonics degree for loading the model."""
+
+
+def main(cfg: Config) -> None:
+    point_dir = cfg.point_path.parent
+    if (point_dir / "smplx_param.npz").exists():
+        model = SMPLXGaussianModel(cfg.sh_degree)
+    elif (point_dir / "flame_param.npz").exists():
+        model = FlameGaussianModel(cfg.sh_degree)
+    else:
+        model = GaussianModel(cfg.sh_degree)
+
+    model.load_ply(cfg.point_path, motion_path=cfg.motion_path, has_target=False)
+
+    if model.binding is not None:
+        model.select_mesh_by_timestep(cfg.timestep)
+
+    model.save_ply(cfg.output_path, use_global=True)
+
+
+if __name__ == "__main__":
+    tyro.cli(main)
+

--- a/scene/flame_gaussian_model.py
+++ b/scene/flame_gaussian_model.py
@@ -216,8 +216,8 @@ class FlameGaussianModel(GaussianModel):
         # param_dynamic_offset = {'params': [self.flame_param['dynamic_offset']], 'lr': 1.6e-6, "name": "dynamic_offset"}
         # self.optimizer.add_param_group(param_dynamic_offset)
 
-    def save_ply(self, path):
-        super().save_ply(path)
+    def save_ply(self, path, use_global: bool = False):
+        super().save_ply(path, use_global=use_global)
 
         npz_path = Path(path).parent / "flame_param.npz"
         flame_param = {k: v.cpu().numpy() for k, v in self.flame_param.items()}

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -250,16 +250,32 @@ class GaussianModel:
                 l.append('binding_{}'.format(i))
         return l
 
-    def save_ply(self, path):
+    def save_ply(self, path, use_global=False):
+        """Export the Gaussian point cloud to a PLY file.
+
+        Parameters
+        ----------
+        path : str or Path
+            Destination path of the PLY file.
+        use_global : bool, optional
+            When ``True`` the points are exported in world coordinates with
+            global scale and rotation; otherwise the raw local values are
+            written.  ``False`` by default.
+        """
         mkdir_p(os.path.dirname(path))
 
-        xyz = self._xyz.detach().cpu().numpy()
+        if use_global:
+            xyz = self.get_xyz.detach().cpu().numpy()
+            scale = self.get_scaling.detach().cpu().numpy()
+            rotation = self.get_rotation.detach().cpu().numpy()
+        else:
+            xyz = self._xyz.detach().cpu().numpy()
+            scale = self._scaling.detach().cpu().numpy()
+            rotation = self._rotation.detach().cpu().numpy()
         normals = np.zeros_like(xyz)
         f_dc = self._features_dc.detach().transpose(1, 2).flatten(start_dim=1).contiguous().cpu().numpy()
         f_rest = self._features_rest.detach().transpose(1, 2).flatten(start_dim=1).contiguous().cpu().numpy()
         opacities = self._opacity.detach().cpu().numpy()
-        scale = self._scaling.detach().cpu().numpy()
-        rotation = self._rotation.detach().cpu().numpy()
 
         dtype_full = [(attribute, 'f4') for attribute in self.construct_list_of_attributes()]
 

--- a/scene/smplx_gaussian_model.py
+++ b/scene/smplx_gaussian_model.py
@@ -206,8 +206,8 @@ class SMPLXGaussianModel(GaussianModel):
         ]
         self.optimizer.add_param_group({'params': params, 'lr': training_args.flame_pose_lr, 'name': 'smplx'})
 
-    def save_ply(self, path):
-        super().save_ply(path)
+    def save_ply(self, path, use_global: bool = False):
+        super().save_ply(path, use_global=use_global)
         npz_path = Path(path).parent / 'smplx_param.npz'
         smplx_param = {k: v.cpu().numpy() for k, v in self.smplx_param.items()}
         np.savez(str(npz_path), **smplx_param)


### PR DESCRIPTION
## Summary
- allow `save_ply` to save points in global coordinates
- add `save_global_ply.py` script for converting local PLY files to global ones
- ensure global export uses world-space xyz, scale, and rotation

## Testing
- `python -m py_compile save_global_ply.py scene/gaussian_model.py scene/flame_gaussian_model.py scene/smplx_gaussian_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a42bee84832a84720c9211aeedd2